### PR TITLE
Remove devmode comment

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,10 +7,6 @@ description: |
   NOTE: This is a wrapper of the official package, but it is not verified,
   affiliated with, or supported by AMD.
 
-  NOTE: Currently, the snap only works in `--devmode`. This is not recommended
-  unless you know what you are doing. To learn more about the confinement
-  levels, read https://snapcraft.io/docs/snap-confinement.
-
   The ROCm Validation Suite (RVS) is a system validation and diagnostics tool
   for monitoring, stress testing, detecting and troubleshooting issues that
   affects the functionality and performance of AMD GPU(s) operating in a


### PR DESCRIPTION
~~Currently the snap only works in devmode. [The fix](https://github.com/canonical/snapd/pull/14685) has been merged into snapd, but it has not made it into a release just yet.~~

snapd supports KFD now with the `opengl` plug.

Still waiting on feedback regarding the `/dev/shm` errors: https://forum.snapcraft.io/t/rocm-validation-suite-dev-shm-errors/45672