### PR TITLE
Add sync with upstream workflow

### DIFF
--- a/.github/workflows/sync-with-upstream.yml
+++ b/.github/workflows/sync-with-upstream.yml
@@ -1,0 +1,27 @@
+name: Update
+on:
+  schedule:
+    - cron: '0 10 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    name: Sync version with upstream
+    environment: "Main Branch"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync version with upstream
+        uses: snapcrafters/ci/sync-version@main
+        with:
+          bot-email: actions@github.com
+          bot-name: GitHub Actions
+          token: ${{ secrets.PAT }}
+          update-script: |
+            VERSION=$(curl -sL https://api.github.com/repos/ROCm/ROCmValidationSuite/releases \
+              | jq -r .[0].tag_name | tr -d 'rocm-'
+            )
+            sed -i 's/^\(version: \).*$/\1'"$VERSION"'/' snap/snapcraft.yaml


### PR DESCRIPTION
This is using the [Snapcrafters](https://github.com/snapcrafters/ci) workflow. Not sure if we want to use that or something else. Currently the snap can be built using the snapcraft.io integration with GitHub.

I haven't created the access token, but that should be immediate since we would only need a fine-grained access token.

Additionally, I set up some branch protection rules, but I'm not sure if that will prevent the bot from making commits directly to `main` (which is what it would try to do with this PR). If we want to make the bot create PRs or something else, we would need a different workflow.

This is what I've been using before, but I'm open to suggestions.